### PR TITLE
Fixed the message printed when deploying ClusterIP

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -10,6 +10,5 @@
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "tile38.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward $POD_NAME 8080:9851
 {{- end }}


### PR DESCRIPTION
In the instructions, it printed
Visit http://127.0.0.1:8080 to use your application
kubectl port-forward $POD_NAME 8080:80 
for ClusterIP deployment, 

but it is not 80 but 9851.